### PR TITLE
FPS Limit option

### DIFF
--- a/Headers/LogicalParameter.hpp
+++ b/Headers/LogicalParameter.hpp
@@ -586,9 +586,11 @@ struct LogicalParameter
             KeyPressVisAdvModeWidthScale20,
             KeyPressVisAdvModeFixedHeight20,
 
+            OtherFPSHint,
             OtherSaveStats,
             OtherShowOppOnAlt,
             OtherMultpl,
+            OtherFPSLimit,
 
             SaveStatMaxKPS,
             SaveStatTotal,

--- a/Headers/ParameterLine.hpp
+++ b/Headers/ParameterLine.hpp
@@ -623,6 +623,8 @@ class ParameterLine : public sf::Drawable, public sf::Transformable, public std:
             OtherSaveStats,
             OtherShowOppOnAlt,
             OtherMultpl,
+            OtherFPSHint,
+            OtherFPSLimit,
             OtherMty,
 
             SaveStatColl,

--- a/Headers/Settings.hpp
+++ b/Headers/Settings.hpp
@@ -160,6 +160,7 @@ namespace Settings
     extern bool SaveStats;
     extern bool ShowOppOnAlt;
     extern unsigned ButtonPressMultiplier;
+    extern unsigned FPSLimit;
 
     // Default assets
     extern unsigned char* KeyCountersDefaultFont;

--- a/Source/Application.cpp
+++ b/Source/Application.cpp
@@ -11,7 +11,7 @@
 #include <SFML/Graphics/Transformable.hpp>
 
 
-const sf::Time Application::TimePerFrame = sf::seconds(1.f / 60.f);
+const sf::Time Application::TimePerFrame = sf::seconds(1.f / static_cast<float>(LogicalParameter::ID::OtherFPSLimit));
 
 Application::Application()
 {

--- a/Source/Application.cpp
+++ b/Source/Application.cpp
@@ -450,7 +450,7 @@ void Application::openWindow()
         mWindow.close();
     mWindow.create(sf::VideoMode(getWindowWidth(), getWindowHeight()), "JKPS", style);
     mWindow.setKeyRepeatEnabled(false);
-    mWindow.setFramerateLimit(60);
+    mWindow.setFramerateLimit(Settings::FPSLimit);
 #ifdef linux
     if (style == sf::Style::None)
     {

--- a/Source/Menu.cpp
+++ b/Source/Menu.cpp
@@ -718,7 +718,7 @@ void Menu::buildParametersMap()
     mParameters.emplace(std::make_pair(LogicalParameter::ID::OtherSaveStats,              new LogicalParameter(LogicalParameter::Type::Bool,          &Settings::SaveStats,                                   "Update statistics on quit", "False")));
     mParameters.emplace(std::make_pair(LogicalParameter::ID::OtherShowOppOnAlt,           new LogicalParameter(LogicalParameter::Type::Bool,          &Settings::ShowOppOnAlt,                                "Show opposite key values on alt press", "True")));
     mParameters.emplace(std::make_pair(LogicalParameter::ID::OtherMultpl,                 new LogicalParameter(LogicalParameter::Type::Unsigned,      &Settings::ButtonPressMultiplier,                       "Value to multiply on click", "1", 0, 1000000)));
-    mParameters.emplace(std::make_pair(LogicalParameter::ID::OtherFPSLimit,               new LogicalParameter(LogicalParameter::Type::Unsigned,      &Settings::FPSLimit,                       "FPS Limit", "60", 0, 8000)));
+    mParameters.emplace(std::make_pair(LogicalParameter::ID::OtherFPSLimit,               new LogicalParameter(LogicalParameter::Type::Unsigned,      &Settings::FPSLimit,                                    "FPS Limit", "60", 0, 8000)));
 
     mParameters.emplace(std::make_pair(LogicalParameter::ID::SaveStatMaxKPS,              new LogicalParameter(LogicalParameter::Type::Float,         &Settings::MaxKPS,                                      "Saved max KPS", "0", 0u, UINT_MAX)));
     mParameters.emplace(std::make_pair(LogicalParameter::ID::SaveStatTotal,               new LogicalParameter(LogicalParameter::Type::Unsigned,      &Settings::Total,                                       "Saved total", "0", 0u, UINT_MAX)));

--- a/Source/Menu.cpp
+++ b/Source/Menu.cpp
@@ -718,6 +718,7 @@ void Menu::buildParametersMap()
     mParameters.emplace(std::make_pair(LogicalParameter::ID::OtherSaveStats,              new LogicalParameter(LogicalParameter::Type::Bool,          &Settings::SaveStats,                                   "Update statistics on quit", "False")));
     mParameters.emplace(std::make_pair(LogicalParameter::ID::OtherShowOppOnAlt,           new LogicalParameter(LogicalParameter::Type::Bool,          &Settings::ShowOppOnAlt,                                "Show opposite key values on alt press", "True")));
     mParameters.emplace(std::make_pair(LogicalParameter::ID::OtherMultpl,                 new LogicalParameter(LogicalParameter::Type::Unsigned,      &Settings::ButtonPressMultiplier,                       "Value to multiply on click", "1", 0, 1000000)));
+    mParameters.emplace(std::make_pair(LogicalParameter::ID::OtherFPSLimit,               new LogicalParameter(LogicalParameter::Type::Unsigned,      &Settings::FPSLimit,                       "FPS Limit", "60", 0, 8000)));
 
     mParameters.emplace(std::make_pair(LogicalParameter::ID::SaveStatMaxKPS,              new LogicalParameter(LogicalParameter::Type::Float,         &Settings::MaxKPS,                                      "Saved max KPS", "0", 0u, UINT_MAX)));
     mParameters.emplace(std::make_pair(LogicalParameter::ID::SaveStatTotal,               new LogicalParameter(LogicalParameter::Type::Unsigned,      &Settings::Total,                                       "Saved total", "0", 0u, UINT_MAX)));
@@ -806,6 +807,10 @@ void Menu::buildParameterLines()
     mParameterLines.emplace(std::make_pair(ParameterLine::ID::KeyPressVisAdvModeColl, new ParameterLine(parP, mFonts, mTextures, mWindow)));
     mParameterLines.emplace(std::make_pair(ParameterLine::ID::KeyPressVisAdvModeSpace, new ParameterLine(emptyP, mFonts, mTextures, mWindow)));
     mParameterLines.emplace(std::make_pair(ParameterLine::ID::KeyPressVisAdvModeMty, new ParameterLine(emptyP, mFonts, mTextures, mWindow)));
+
+    parP = sPtr(new LogicalParameter(LogicalParameter::Type::Hint, nullptr, "Recommendation: FPS limit = your keyboard's polling rate\nAfter changing FPS Limit, restart the application"));
+    mParameterLines.emplace(std::make_pair(ParameterLine::ID::OtherFPSHint, new ParameterLine(parP, mFonts, mTextures, mWindow)));
+    mParameterLines[ParameterLine::ID::OtherFPSHint]->setCharacterSize(16u);
 
     parP = sPtr(new LogicalParameter(LogicalParameter::Type::Collection, nullptr, mCollectionNames.at(collectionNameIdx++)));
     mParameterLines.emplace(std::make_pair(ParameterLine::ID::OtherColl, new ParameterLine(parP, mFonts, mTextures, mWindow)));

--- a/Source/Palette.cpp
+++ b/Source/Palette.cpp
@@ -17,7 +17,7 @@ Palette::Palette(int)
 , wasButtonPressedOnLine(false)
 , wasButtonPressedOnCanvas(false)
 {
-    mWindow.setFramerateLimit(60);
+    mWindow.setFramerateLimit(Settings::FPSLimit);
 
     auto color = sf::Color::Red;
     float colorStep = mLineSize / 2, leftSide = 5.f, rightSide = 25.f;

--- a/Source/ParameterLine.cpp
+++ b/Source/ParameterLine.cpp
@@ -1405,9 +1405,11 @@ ParameterLine::ID ParameterLine::parIdToParLineId(LogicalParameter::ID id)
         case LogicalParameter::ID::KeyPressVisAdvModeWidthScale20: return ParameterLine::ID::KeyPressVisAdvModeWidthScale20;
         case LogicalParameter::ID::KeyPressVisAdvModeFixedHeight20: return ParameterLine::ID::KeyPressVisAdvModeFixedHeight20;
 
+        case LogicalParameter::ID::OtherFPSHint: return ParameterLine::ID::OtherFPSHint;
         case LogicalParameter::ID::OtherSaveStats: return ParameterLine::ID::OtherSaveStats;
         case LogicalParameter::ID::OtherShowOppOnAlt: return ParameterLine::ID::OtherShowOppOnAlt;
         case LogicalParameter::ID::OtherMultpl: return ParameterLine::ID::OtherMultpl;
+        case LogicalParameter::ID::OtherFPSLimit: return ParameterLine::ID::OtherFPSLimit;
 
         case LogicalParameter::ID::SaveStatMaxKPS: return ParameterLine::ID::SaveStatMaxKPS;
         case LogicalParameter::ID::SaveStatTotal: return ParameterLine::ID::SaveStatTotal;

--- a/Source/Settings.cpp
+++ b/Source/Settings.cpp
@@ -145,6 +145,7 @@ Container<float> KeyPressAdvFixedHeight;
 bool SaveStats;
 bool ShowOppOnAlt;
 unsigned ButtonPressMultiplier;
+unsigned FPSLimit;
 
 // Default assets
 unsigned char* StatisticsDefaultFont = MainProgramFont;


### PR DESCRIPTION
fixes #21

Set the highest possible FPSLimit, or at least at your keyboard polling rate.

SFML will poll at FPSLimit, preventing any dropped keyboard polls, resulting in undetected release (example: 2 clicks becomes 1 hold)